### PR TITLE
Various fixes to enable build on OSX

### DIFF
--- a/FrameCapturer/Assets/FrameCapturer/Scripts/FrameCapturer.cs
+++ b/FrameCapturer/Assets/FrameCapturer/Scripts/FrameCapturer.cs
@@ -23,7 +23,9 @@ public static class FrameCapturer
         public int max_data_size;
     };
 
+#if UNITY_STANDALONE_WIN
     [DllImport ("AddLibraryPath")] public static extern void    AddLibraryPath();
+#endif
 
     [DllImport ("FrameCapturer")] public static extern IntPtr   fcExrCreateContext(ref fcExrConfig conf);
     [DllImport ("FrameCapturer")] public static extern void     fcExrDestroyContext(IntPtr ctx);

--- a/FrameCapturer/Assets/FrameCapturer/Scripts/GifCapturer.cs
+++ b/FrameCapturer/Assets/FrameCapturer/Scripts/GifCapturer.cs
@@ -34,8 +34,10 @@ public class GifCapturer : MovieCapturer
 
     GifCapturer()
     {
+#if UNITY_STANDALONE_WIN
         // Plugins/* を dll サーチパスに追加
         try { FrameCapturer.AddLibraryPath(); } catch { }
+#endif
     }
 
     public override bool recode

--- a/FrameCapturer/Assets/FrameCapturer/Scripts/GifOffscreenCapturer.cs
+++ b/FrameCapturer/Assets/FrameCapturer/Scripts/GifOffscreenCapturer.cs
@@ -33,8 +33,10 @@ public class GifOffscreenCapturer : MovieCapturer
 
     GifOffscreenCapturer()
     {
+#if UNITY_STANDALONE_WIN
         // Plugins/* を dll サーチパスに追加
         try { FrameCapturer.AddLibraryPath(); } catch { }
+#endif
     }
 
     public override bool recode

--- a/Plugin/FrameCapturer.cpp
+++ b/Plugin/FrameCapturer.cpp
@@ -68,9 +68,9 @@ fcIGifContext* fcCreateGifContext(fcGifConfig &conf, fcIGraphicsDevice *dev);
 
 fcCLinkage fcExport fcIGifContext* fcGifCreateContext(fcGifConfig *conf)
 {
-    if (fcCreateGifContext == nullptr) {
-        // todo
-    }
+    // if (fcCreateGifContext == nullptr) {
+    //     // todo
+    // }
     return fcCreateGifContext(*conf, fcGetGraphicsDevice());
 }
 

--- a/Plugin/external/jo_gif.cpp
+++ b/Plugin/external/jo_gif.cpp
@@ -222,8 +222,15 @@ static void jo_gif_lzw_write(jo_gif_lzw_t *s, int code)
 
 static void jo_gif_lzw_encode(std::ostream &os, unsigned char *in, int len)
 {
-    jo_gif_lzw_t state = {&os, 9};
+    jo_gif_lzw_t state;
     int maxcode = 511;
+    
+    state.os = &os;
+    state.numBits = 9;
+    state.idx = 0;
+    state.tmp = 0;
+    state.outBits = 0;
+    state.curBits = 0;
 
     // Note: 30k stack space for dictionary =|
     const int hashSize = 5003;
@@ -378,7 +385,7 @@ void jo_gif_decode(void *o_buf, jo_gif_frame_t *fdata, jo_gif_frame_t *palette_f
 }
 
 
-void jo_gif_end(jo_gif_t *gif)
+void jo_gif_end(jo_gif_t *)
 {
 }
 
@@ -398,7 +405,7 @@ void jo_gif_write_frame(std::ostream &os, jo_gif_t *gif, jo_gif_frame_t *fdata, 
 {
     short width = gif->width;
     short height = gif->height;
-    int size = width * height;
+    // int size = width * height;
     unsigned char *palette = nullptr;
     int palette_size = 0;
     if (palette_optional != nullptr) {
@@ -440,7 +447,7 @@ void jo_gif_write_frame(std::ostream &os, jo_gif_t *gif, jo_gif_frame_t *fdata, 
     os.put(0); // block terminator
 }
 
-void jo_gif_write_footer(std::ostream &os, jo_gif_t *gif)
+void jo_gif_write_footer(std::ostream &os, jo_gif_t *)
 {
     os.put(0x3b); // gif trailer
 }

--- a/Plugin/fcExrFile.cpp
+++ b/Plugin/fcExrFile.cpp
@@ -12,12 +12,16 @@
 #include <ImfStringAttribute.h>
 #include <ImfMatrixAttribute.h>
 #include <ImfArray.h>
+
+#if defined(fcWindows) && !defined(fcNoAutoLink)
 #pragma comment(lib, "Half.lib")
 #pragma comment(lib, "Iex-2_2.lib")
 #pragma comment(lib, "IexMath-2_2.lib")
 #pragma comment(lib, "IlmThread-2_2.lib")
 #pragma comment(lib, "IlmImf-2_2.lib")
 #pragma comment(lib, "zlibstatic.lib")
+#endif
+
 #include "fcExrFile.h"
 
 

--- a/Plugin/fcGifFile.cpp
+++ b/Plugin/fcGifFile.cpp
@@ -5,7 +5,7 @@
 #include "fcThreadPool.h"
 #include "fcGraphicsDevice.h"
 #include "fcGifFile.h"
-#include "jo_gif.cpp"
+#include "external/jo_gif.cpp"
 
 
 
@@ -103,7 +103,7 @@ void fcGifContext::scrape(bool updating)
     // 最大フレーム数超えてたら間引く
     if (m_conf.max_frame > 0)
     {
-        while (m_conf.max_frame > min_frames && m_gif_buffers.size() > m_conf.max_frame)
+        while (m_conf.max_frame > min_frames && m_gif_buffers.size() > size_t(m_conf.max_frame))
         {
             advance_palette_and_pop_front(m_gif_buffers);
         }
@@ -119,7 +119,7 @@ void fcGifContext::scrape(bool updating)
             size += fdata.palette.size() + fdata.encoded.size() + 20;
         }
 
-        while (m_gif_buffers.size() > min_frames && size > m_conf.max_data_size)
+        while (m_gif_buffers.size() > size_t(min_frames) && size > size_t(m_conf.max_data_size))
         {
             auto &fdata = m_gif_buffers.front();
             size -= fdata.palette.size() + fdata.encoded.size() + 20;
@@ -247,7 +247,7 @@ int fcGifContext::getFrameCount()
 
 void fcGifContext::getFrameData(void *tex, int frame)
 {
-    if (frame >= m_gif_buffers.size()) { return; }
+    if (frame >= 0 && size_t(frame) >= m_gif_buffers.size()) { return; }
     m_tasks.wait();
     scrape(false);
 

--- a/Plugin/fcGraphicsDevice.cpp
+++ b/Plugin/fcGraphicsDevice.cpp
@@ -20,6 +20,9 @@ int fcGetPixelSize(fcETextureFormat format)
     case fcE_ARGBInt:   return 16;
     case fcE_RGInt:     return 8;
     case fcE_RInt:      return 4;
+    
+    default:
+         break;
     }
     return 0;
 }
@@ -64,7 +67,7 @@ fcCLinkage fcExport void UnitySetGraphicsDevice(void* device, int deviceType, in
     }
 }
 
-fcCLinkage fcExport void UnityRenderEvent(int eventID)
+fcCLinkage fcExport void UnityRenderEvent(int)
 {
 }
 

--- a/Plugin/fcGraphicsDeviceOpenGL.cpp
+++ b/Plugin/fcGraphicsDeviceOpenGL.cpp
@@ -4,10 +4,15 @@
 
 #ifdef fcSupportOpenGL
 
+#ifndef fcDontForceStaticGLEW
 #define GLEW_STATIC
+#endif
 #include <GL/glew.h>
+
+#if defined(fcWindows) && !defined(fcNoAutoLink)
 #pragma comment(lib, "opengl32.lib")
 #pragma comment(lib, "glew32s.lib")
+#endif
 
 
 class fcGraphicsDeviceOpenGL : public fcIGraphicsDevice
@@ -62,10 +67,12 @@ static void fcGetInternalFormatOpenGL(fcETextureFormat format, GLenum &o_fmt, GL
     case fcE_ARGBInt:   o_fmt = GL_RGBA_INTEGER; o_type = GL_INT; return;
     case fcE_RGInt:     o_fmt = GL_RG_INTEGER; o_type = GL_INT; return;
     case fcE_RInt:      o_fmt = GL_RED_INTEGER; o_type = GL_INT; return;
+    default:
+        break;
     }
 }
 
-bool fcGraphicsDeviceOpenGL::readTexture(void *o_buf, size_t bufsize, void *tex, int width, int height, fcETextureFormat format)
+bool fcGraphicsDeviceOpenGL::readTexture(void *o_buf, size_t, void *tex, int, int, fcETextureFormat format)
 {
     GLenum internal_format = 0;
     GLenum internal_type = 0;
@@ -81,7 +88,7 @@ bool fcGraphicsDeviceOpenGL::readTexture(void *o_buf, size_t bufsize, void *tex,
     return true;
 }
 
-bool fcGraphicsDeviceOpenGL::writeTexture(void *o_tex, int width, int height, fcETextureFormat format, const void *buf, size_t bufsize)
+bool fcGraphicsDeviceOpenGL::writeTexture(void *o_tex, int width, int height, fcETextureFormat format, const void *buf, size_t)
 {
     GLenum internal_format = 0;
     GLenum internal_type = 0;

--- a/Plugin/pch.h
+++ b/Plugin/pch.h
@@ -17,7 +17,7 @@
     #define fcExport __declspec(dllexport)
     #define fcBreak() DebugBreak()
 #else // fcWindows
-    #define fcExport
+    #define fcExport __attribute__((visibility("default")))
     #define fcBreak() __builtin_trap()
 #endif // fcWindows
 


### PR DESCRIPTION
add fcNoAutoLink define to optionally disable pragma based library linking
disable lib pragma on other platform than windows
add fcDontForceStaticGLEW to disable definition of GLEW_STATIC in source
properly set symbol visibility macro for non-windows platform
do not use AddLibraryPath on other platform than windows
fix several build errors and warnings on OSX