### PR TITLE
Fixed an error in the unmapped resources.

### DIFF
--- a/Plugin/GraphicsDevice/fcGraphicsDeviceD3D11.cpp
+++ b/Plugin/GraphicsDevice/fcGraphicsDeviceD3D11.cpp
@@ -169,7 +169,7 @@ bool fcGraphicsDeviceD3D11::readTexture(void *o_buf, size_t bufsize, void *tex_,
             }
         }
 
-        m_context->Unmap(tex, 0);
+        m_context->Unmap(tmp, 0);
         return true;
     }
     return false;


### PR DESCRIPTION
Unmapを行っているリソースが誤っているので修正。

CopyResourceを手動で待っている箇所がありますが、
Map,Unmapが一対になっていれば不要だと思ったのですが、
(Mapされた状態のままで、再度Mapが呼ばれるの処理されない)
自分の環境では、待たなければならない状況が再現できず、動作が確認できなかったため、未対応です。