### PR TITLE
Add RGBA support to MovieRecorder

### DIFF
--- a/FrameCapturer/Assets/UTJ/FrameCapturer/Editor/MovieRecorderEditor.cs
+++ b/FrameCapturer/Assets/UTJ/FrameCapturer/Editor/MovieRecorderEditor.cs
@@ -38,6 +38,10 @@ namespace UTJ.FrameCapturer
 
             CommonConfig();
 
+            if(recorder.supportVideoWithAlpha) {
+                EditorGUILayout.PropertyField(so.FindProperty("m_captureColorComponent"));
+            }
+
             EditorGUILayout.Space();
 
             if (recorder.supportVideo && !recorder.supportAudio)

--- a/FrameCapturer/Assets/UTJ/FrameCapturer/Scripts/Encoder/MovieEncoder.cs
+++ b/FrameCapturer/Assets/UTJ/FrameCapturer/Scripts/Encoder/MovieEncoder.cs
@@ -33,6 +33,19 @@ namespace UTJ.FrameCapturer
             }
         }
 
+        public bool supportVideoWithAlpha
+        {
+            get {
+                /// @todo Test for other formats
+                return
+                  format == MovieEncoder.Type.Png
+                  // || format == MovieEncoder.Type.Exr
+                  // || format == MovieEncoder.Type.Gif
+                  // || format == MovieEncoder.Type.WebM
+                  ;
+            }
+        }
+
         public bool supportAudio
         {
             get


### PR DESCRIPTION
Since `MovieRecorder` is the most easy way to make still images for compositing, it'd be nice to have RGBA format as its option.

- note(1): It only works with RenderTexture.  It means we must set RenderTexture to MovieRecorder's "Capture Target" and "Target RT" explicitly.
- note(2): It only supports `.png` format for now.  We need more serious test for other formats.