### PR TITLE
Add basic initialisation to build.bat

### DIFF
--- a/Plugin/build.bat
+++ b/Plugin/build.bat
@@ -1,3 +1,5 @@
+setlocal
+cd /d "%~dp0"
 call toolchain.bat
 
 msbuild fccore.sln /t:Build /p:Configuration=Master /p:Platform=x64 /m /nologo


### PR DESCRIPTION
Super trivial PR again 😃 

(1) setlocal
Before this changeset, when we continuously call build.bat from same cmd.exe terminal, some environment variables are exceeded maximum length by toolchain.bat (actually VsDevCmd.bat).  Because it keep adding same locations to %PATH%.

To avoid this issue, we need setlocal in the beginning of the file.

(2) cd /d "%~dp0"
It allows us to call build.bat from anywhere!