### PR TITLE
Only limit framerate while recording

### DIFF
--- a/FrameCapturer/Assets/UTJ/FrameCapturer/Scripts/RecorderBase.cs
+++ b/FrameCapturer/Assets/UTJ/FrameCapturer/Scripts/RecorderBase.cs
@@ -209,7 +209,7 @@ namespace UTJ.FrameCapturer
             float wt = (1.0f / m_targetFramerate) * (Time.renderedFrameCount - m_initialFrame);
             while (Time.realtimeSinceStartup - m_initialRealTime < wt)
             {
-                System.Threading.Thread.Sleep(1);
+                System.Threading.Thread.Yield();
             }
         }
 
@@ -285,9 +285,12 @@ namespace UTJ.FrameCapturer
                 {
                 }
 
-                if(m_framerateMode == FrameRateMode.Constant && m_fixDeltaTime && m_waitDeltaTime)
+                if (m_recording)
                 {
-                    StartCoroutine(Wait());
+                    if (m_framerateMode == FrameRateMode.Constant && m_fixDeltaTime && m_waitDeltaTime)
+                    {
+                        StartCoroutine(Wait());
+                    }
                 }
             }
         }

--- a/FrameCapturer/Assets/UTJ/FrameCapturer/Scripts/RecorderBase.cs
+++ b/FrameCapturer/Assets/UTJ/FrameCapturer/Scripts/RecorderBase.cs
@@ -209,7 +209,7 @@ namespace UTJ.FrameCapturer
             float wt = (1.0f / m_targetFramerate) * (Time.renderedFrameCount - m_initialFrame);
             while (Time.realtimeSinceStartup - m_initialRealTime < wt)
             {
-                System.Threading.Thread.Yield();
+                System.Threading.Thread.Sleep(1);
             }
         }
 


### PR DESCRIPTION
Currently the component must be disabled to prevent it from capping the frame rate if it's set to constant with Fix Delta Time and Wait Delta Time.

This PR adds a very little change that prevents the component limiting the frame rate unless it is currently recording.